### PR TITLE
Test a compiled Symfony2 Container as that is what SF2 normally uses in production.

### DIFF
--- a/symfonydi/test1.php
+++ b/symfonydi/test1.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 require_once '../testclasses.php';
 
 function __autoload($className)
@@ -23,6 +23,14 @@ $container = new Symfony\Component\DependencyInjection\ContainerBuilder;
 $definition = new Symfony\Component\DependencyInjection\Definition('A', []);
 $definition->setScope('prototype');
 $container->setDefinition('A', $definition);
+
+$dumper = new Symfony\Component\DependencyInjection\Dumper\PhpDumper($container);
+
+$class = 'BenchmarkContainer';
+$rawContainer = $dumper->dump(['class' => $class, 'base_class' => 'Container']);
+eval('?>' . $rawContainer);
+
+$container = new $class();
 
 
 $t1 = microtime(true);

--- a/symfonydi/test2.php
+++ b/symfonydi/test2.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 require_once '../testclasses.php';
 
 function __autoload($className)
@@ -22,6 +22,14 @@ $container = new Symfony\Component\DependencyInjection\ContainerBuilder;
 $definition = new Symfony\Component\DependencyInjection\Definition('A', []);
 $definition->setScope('prototype');
 $container->setDefinition('A', $definition);
+
+$dumper = new Symfony\Component\DependencyInjection\Dumper\PhpDumper($container);
+
+$class = 'BenchmarkContainer';
+$rawContainer = $dumper->dump(['class' => $class, 'base_class' => 'Container']);
+eval('?>' . $rawContainer);
+
+$container = new $class();
 
 //Trigger the autoloader
 $a = $container->get('A');

--- a/symfonydi/test3.php
+++ b/symfonydi/test3.php
@@ -32,6 +32,14 @@ for ($i = 0; $i < count($classes); $i++) {
 }
 
 
+$dumper = new Symfony\Component\DependencyInjection\Dumper\PhpDumper($container);
+
+$class = 'BenchmarkContainer';
+$rawContainer = $dumper->dump(['class' => $class, 'base_class' => 'Container']);
+eval('?>' . $rawContainer);
+
+$container = new $class();
+
 //Trigger autoloader
 $a = $container->get('J');
 unset($a);

--- a/symfonydi/test4.php
+++ b/symfonydi/test4.php
@@ -21,6 +21,14 @@ function __autoload($className)
 $container = new Symfony\Component\DependencyInjection\ContainerBuilder;
 $container->register('A', 'A');
 
+$dumper = new Symfony\Component\DependencyInjection\Dumper\PhpDumper($container);
+
+$class = 'BenchmarkContainer';
+$rawContainer = $dumper->dump(['class' => $class, 'base_class' => 'Container']);
+eval('?>' . $rawContainer);
+
+$container = new $class();
+
 //Trigger autoloader
 $a = $container->get('A');
 unset($a);

--- a/symfonydi/test5.php
+++ b/symfonydi/test5.php
@@ -27,6 +27,14 @@ $definition = new Symfony\Component\DependencyInjection\Definition('B', $ref );
 $definition->setScope('prototype');
 $container->setDefinition('B', $definition);
 
+$dumper = new Symfony\Component\DependencyInjection\Dumper\PhpDumper($container);
+
+$class = 'BenchmarkContainer';
+$rawContainer = $dumper->dump(['class' => $class, 'base_class' => 'Container']);
+eval('?>' . $rawContainer);
+
+$container = new $class();
+
 //trigger autoloader
 $a = $container->get('B');
 unset($a);


### PR DESCRIPTION
Symfony normally only compiles the container once when the cache is regenerated.

The $rawContainer is normally dumped to disk and then required later.
This is why the Container class you've been using is called ContainerBuilder; because you use it to build a Container and then write it to disk.

On my machine I went from 0.2 sec to 0.02 sec on the tests.
