### PR TITLE
fix typo in testclasses

### DIFF
--- a/testclasses.php
+++ b/testclasses.php
@@ -85,7 +85,7 @@ class J {
 class K {
 	public $j;
 	
-	public function __construct(K $k) {
-		$this->k = $k;
+	public function __construct(J $j) {
+		$this->j = $j;
 	}
 }


### PR DESCRIPTION
this may have an effect on your performance results given the way dice works? (K was originally __construct(K) rather than __construct(J) as intended?)
